### PR TITLE
Add Nonary Engram contents to Rite of the Nine

### DIFF
--- a/src/setData/yearSeven.js
+++ b/src/setData/yearSeven.js
@@ -734,46 +734,46 @@ export default ([
             name: 'Nonary Engram',
             season: 26,
             items: [
-                2515305906, // Kingmaker
-                1871253230, // Patient Zero
-                2452241573, // Dead Man's Revenge
-                476682455, // One Terrible Scream
-                116193775, // Ashen Icon
-                4231724739, // Atropos
-                2511583696, // Winged Wolf
-                885220736, // Fist of Fury
-                876119751, // Iron Severance
-                2504641454, // Golden Age Dropkick
-                4039153625, // All Four Barrels
-                2837446538, // A Sour Taste
-                3358915164, // Commanding Presence
-                484425890, // Dawn of Invention
-                2218275250, // Chair Pop
-                1194404806, // Cowbell
-                2370712399, // Spring Showers
-                1749473785, // Galloping Knight
-                1345789366, // Heartfelt Union
-                2144724879, // Patty Cake
-                1032515587, // Whisper Sweet Nothings
-                3733702441, // Wolven Shell
-                1106697448, // S.H.A.N.K. Shell
-                2716406907, // Crimson Shell
-                4005536860, // Simulation Shell
-                443190222, // Drop Pod Shell
-                2924794318, // Solpiercer
-                2417017737, // Ada-1's Lone Wolf
-                460688466, // Death to Kells
-                2503134037, // Eriana's Vengeance
-                292872936, // Sails of Osiris
-                952431287, // Roach-VGH
-                3397132454, // Skitterscare
-                320750826, // Eira's Grace
-                3268592503, // The Bronco
-                406589950, // SK-1 Multiband Rover
-                3545885626, // Warsat Arrival
-                1378231105, // Cabal Shield Breaker
-                980268772, // Ardent Adoration
-                1912260805, // Taking Flight
+              2515305906, // Kingmaker
+              1871253230, // Patient Zero
+              2452241573, // Dead Man's Revenge
+              476682455, // One Terrible Scream
+              116193775, // Ashen Icon
+              4231724739, // Atropos
+              2511583696, // Winged Wolf
+              885220736, // Fist of Fury
+              876119751, // Iron Severance
+              2504641454, // Golden Age Dropkick
+              4039153625, // All Four Barrels
+              2837446538, // A Sour Taste
+              3358915164, // Commanding Presence
+              484425890, // Dawn of Invention
+              2218275250, // Chair Pop
+              1194404806, // Cowbell
+              2370712399, // Spring Showers
+              1749473785, // Galloping Knight
+              1345789366, // Heartfelt Union
+              2144724879, // Patty Cake
+              1032515587, // Whisper Sweet Nothings
+              3733702441, // Wolven Shell
+              1106697448, // S.H.A.N.K. Shell
+              2716406907, // Crimson Shell
+              4005536860, // Simulation Shell
+              443190222, // Drop Pod Shell
+              2924794318, // Solpiercer
+              2417017737, // Ada-1's Lone Wolf
+              460688466, // Death to Kells
+              2503134037, // Eriana's Vengeance
+              292872936, // Sails of Osiris
+              952431287, // Roach-VGH
+              3397132454, // Skitterscare
+              320750826, // Eira's Grace
+              3268592503, // The Bronco
+              406589950, // SK-1 Multiband Rover
+              3545885626, // Warsat Arrival
+              1378231105, // Cabal Shield Breaker
+              980268772, // Ardent Adoration
+              1912260805, // Taking Flight
             ],
           },
         ],

--- a/src/setData/yearSeven.js
+++ b/src/setData/yearSeven.js
@@ -730,6 +730,52 @@ export default ([
               2412474869, // Astrograph (Shader)
             ],
           },
+          {
+            name: 'Nonary Engram',
+            season: 26,
+            items: [
+                2515305906, // Kingmaker
+                1871253230, // Patient Zero
+                2452241573, // Dead Man's Revenge
+                476682455, // One Terrible Scream
+                116193775, // Ashen Icon
+                4231724739, // Atropos
+                2511583696, // Winged Wolf
+                885220736, // Fist of Fury
+                876119751, // Iron Severance
+                2504641454, // Golden Age Dropkick
+                4039153625, // All Four Barrels
+                2837446538, // A Sour Taste
+                3358915164, // Commanding Presence
+                484425890, // Dawn of Invention
+                2218275250, // Chair Pop
+                1194404806, // Cowbell
+                2370712399, // Spring Showers
+                1749473785, // Galloping Knight
+                1345789366, // Heartfelt Union
+                2144724879, // Patty Cake
+                1032515587, // Whisper Sweet Nothings
+                3733702441, // Wolven Shell
+                1106697448, // S.H.A.N.K. Shell
+                2716406907, // Crimson Shell
+                4005536860, // Simulation Shell
+                443190222, // Drop Pod Shell
+                2924794318, // Solpiercer
+                2417017737, // Ada-1's Lone Wolf
+                460688466, // Death to Kells
+                2503134037, // Eriana's Vengeance
+                292872936, // Sails of Osiris
+                952431287, // Roach-VGH
+                3397132454, // Skitterscare
+                320750826, // Eira's Grace
+                3268592503, // The Bronco
+                406589950, // SK-1 Multiband Rover
+                3545885626, // Warsat Arrival
+                1378231105, // Cabal Shield Breaker
+                980268772, // Ardent Adoration
+                1912260805, // Taking Flight
+            ],
+          },
         ],
       },
     ],


### PR DESCRIPTION
Bungie is adding a Rite of the Nine engram with assorted cosmetics in a few weeks:
https://www.light.gg/db/vendors/2568871258/nonary-engram/

This adds a list for these items under the "Rite of the Nine" section.